### PR TITLE
Mark thread as unread on comment update

### DIFF
--- a/api/comments.rb
+++ b/api/comments.rb
@@ -23,6 +23,7 @@ put "#{APIPREFIX}/comments/:comment_id" do |comment_id|
   if comment.errors.any?
     error 400, comment.errors.full_messages.to_json
   else
+    user.mark_as_read(comment.comment_thread)
     comment.to_hash.to_json
   end
 end

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -54,6 +54,7 @@ class Comment < Content
 
   before_destroy :destroy_children
   before_create :set_thread_last_activity_at
+  after_update :set_thread_last_activity_at
   before_save :set_sk
 
   def self.hash_tree(nodes)

--- a/presenters/thread_utils.rb
+++ b/presenters/thread_utils.rb
@@ -31,7 +31,7 @@ module ThreadUtils
             unread_comment_count = Comment.collection.find(
               :comment_thread_id => t._id,
               :author_id => {"$ne" => user.id},
-              :created_at => {"$gte" => read_dates[thread_key]}
+              :updated_at => {"$gte" => read_dates[thread_key]}
               ).count
             read_states[thread_key] = [is_read, unread_comment_count]
           end


### PR DESCRIPTION
Updating a comment on a thread must mark
the thread unread for all other users and
also increase the unread comment count
accordingly

Signed-off-by: Shahbaz Nazir <shahbaz.nazir@arbisoft.com>